### PR TITLE
.live() -> .on()

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -8,7 +8,7 @@ $(function() {
   }
   
   // Click listener to change fullscreen preference
-  $('#fullscreen').live('change', function() {
+  $('#fullscreen').on('change', function() {
     if($(this).is(':checked')){
       fullscreen = true;
       localStorage['fullscreen'] = true;


### PR DESCRIPTION
.live() was deprecated in 1.7 see: http://api.jquery.com/live/
